### PR TITLE
fix next_id when we have more then one egui instance

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ lazy_static::lazy_static! {
 #[cfg(feature = "render_element")]
 fn next_id() -> usize {
     let mut ids = EGUI_IDS.lock().unwrap();
-    debug_assert!(!(ids.len() == usize::MAX));
+    debug_assert!(ids.len() != usize::MAX);
     let mut id = EGUI_ID.fetch_add(1, Ordering::SeqCst);
     while ids.iter().any(|k| *k == id) {
         id = EGUI_ID.fetch_add(1, Ordering::SeqCst);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ lazy_static::lazy_static! {
 #[cfg(feature = "render_element")]
 fn next_id() -> usize {
     let mut ids = EGUI_IDS.lock().unwrap();
-    debug_assert!(!ids.len() == usize::MAX);
+    debug_assert!(!(ids.len() == usize::MAX));
     let mut id = EGUI_ID.fetch_add(1, Ordering::SeqCst);
     while ids.iter().any(|k| *k == id) {
         id = EGUI_ID.fetch_add(1, Ordering::SeqCst);


### PR DESCRIPTION
The line:
```
debug_assert!(!ids.len() == usize::MAX);
```
triggers a panic when creating more then one EguiState, it happens because ! is applied too ids.len() and now the whole statement. 1 becomes here -2 with is probably  then casted back to unsigned with ends up with MAX I assume.
