### PR TITLE
fix next texture after egui call not visible in render output

### DIFF
--- a/src/rendering/mod.rs
+++ b/src/rendering/mod.rs
@@ -166,6 +166,7 @@ impl GlState {
 
         gl.BindVertexArray(0);
         gl.BindBuffer(ffi::ELEMENT_ARRAY_BUFFER, 0);
+        gl.BindBuffer(ffi::ARRAY_BUFFER, 0);
         gl.Disable(ffi::SCISSOR_TEST);
 
         Ok(())


### PR DESCRIPTION
If some textures are drawn after egui like for example a mouse cursor, windows they first texture directly after egui call is not visible in the render output.
This happens because in paint_mesh a buffer is bound too ffi::ARRAY_BUFFER and it not cleared when exiting paint_meshes.
PR adds the right call to fix that issue.
