### PR TITLE
implement reactive mode from egui

### DIFF
--- a/examples/integrate.rs
+++ b/examples/integrate.rs
@@ -150,7 +150,6 @@ fn main() -> Result<()> {
                         frame,
                         (0, 0).into(),
                         &[Rectangle::from_loc_and_size((0, 0), size).to_logical(1)],
-                        egui_frame.geometry(),
                     )
                 }
             })?

--- a/examples/integrate.rs
+++ b/examples/integrate.rs
@@ -11,7 +11,7 @@ use smithay::{
         SERIAL_COUNTER,
     },
 };
-use smithay_egui::EguiState;
+use smithay_egui::{EguiMode, EguiState};
 use std::cell::RefCell;
 
 // This example provides a minimal example to:
@@ -31,7 +31,7 @@ fn main() -> Result<()> {
     // create a winit-backend
     let (mut backend, mut input) = winit::init(None)?;
     // create an `EguiState`. Usually this would be part of your global smithay state
-    let mut egui = EguiState::new();
+    let mut egui = EguiState::new(EguiMode::Reactive);
     // you might also need additional structs to store your ui-state, like the demo_lib does
     let mut demo_ui = egui_demo_lib::DemoWindows::default();
     // this is likely already part of your ui-state for `send_frames` and similar
@@ -143,7 +143,14 @@ fn main() -> Result<()> {
                     [1.0, 1.0, 1.0, 1.0],
                     &[Rectangle::from_loc_and_size((0, 0), size)],
                 )?;
-                unsafe { egui_frame.draw(renderer, frame, (0, 0).into()) }
+                unsafe {
+                    egui_frame.draw(
+                        renderer,
+                        frame,
+                        (0, 0).into(),
+                        &[Rectangle::from_loc_and_size((0, 0), size).to_logical(1)],
+                    )
+                }
             })?
             .map_err(|err| anyhow::format_err!("{}", err))?;
         backend.submit(None, 1.0)?;

--- a/examples/integrate.rs
+++ b/examples/integrate.rs
@@ -4,6 +4,7 @@ use smithay::{
         renderer::{Frame, Renderer},
         winit,
     },
+    desktop::space::RenderElement,
     reexports::wayland_server::Display,
     utils::{Rectangle, Transform},
     wayland::{
@@ -149,6 +150,7 @@ fn main() -> Result<()> {
                         frame,
                         (0, 0).into(),
                         &[Rectangle::from_loc_and_size((0, 0), size).to_logical(1)],
+                        egui_frame.geometry(),
                     )
                 }
             })?

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -311,6 +311,7 @@ impl EguiFrame {
         frame: &Gles2Frame,
         location: Point<i32, Physical>,
         damage: &[Rectangle<i32, Logical>],
+        geometry: Rectangle<i32, Logical>,
     ) -> Result<(), Gles2Error> {
         use rendering::GlState;
 
@@ -329,6 +330,7 @@ impl EguiFrame {
                 gl,
                 location,
                 damage,
+                geometry,
                 self.size,
                 self.scale,
                 self.mesh
@@ -404,6 +406,7 @@ impl RenderElement<Gles2Renderer, Gles2Frame, Gles2Error, Gles2Texture> for Egui
                 frame,
                 location.to_f64().to_physical(scale).to_i32_round(),
                 damage,
+                self.geometry(),
             )
         } {
             slog::error!(log, "egui rendering error: {}", err);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -311,7 +311,6 @@ impl EguiFrame {
         frame: &Gles2Frame,
         location: Point<i32, Physical>,
         damage: &[Rectangle<i32, Logical>],
-        geometry: Rectangle<i32, Logical>,
     ) -> Result<(), Gles2Error> {
         use rendering::GlState;
 
@@ -330,7 +329,7 @@ impl EguiFrame {
                 gl,
                 location,
                 damage,
-                geometry,
+                self.geometry(),
                 self.size,
                 self.scale,
                 self.mesh
@@ -359,15 +358,8 @@ impl EguiFrame {
         })
         .and_then(std::convert::identity)
     }
-}
 
-#[cfg(feature = "render_element")]
-impl RenderElement<Gles2Renderer, Gles2Frame, Gles2Error, Gles2Texture> for EguiFrame {
-    fn id(&self) -> usize {
-        self.state_id
-    }
-
-    fn geometry(&self) -> Rectangle<i32, Logical> {
+    pub fn geometry(&self) -> Rectangle<i32, Logical> {
         let area = self.area.to_f64();
 
         let used = self.ctx.used_rect();
@@ -377,6 +369,17 @@ impl RenderElement<Gles2Renderer, Gles2Frame, Gles2Error, Gles2Texture> for Egui
         )
         .to_logical(self.scale)
         .to_i32_round()
+    }
+}
+
+#[cfg(feature = "render_element")]
+impl RenderElement<Gles2Renderer, Gles2Frame, Gles2Error, Gles2Texture> for EguiFrame {
+    fn id(&self) -> usize {
+        self.state_id
+    }
+
+    fn geometry(&self) -> Rectangle<i32, Logical> {
+        EguiFrame::geometry(self)
     }
 
     fn accumulated_damage(
@@ -406,7 +409,6 @@ impl RenderElement<Gles2Renderer, Gles2Frame, Gles2Error, Gles2Texture> for Egui
                 frame,
                 location.to_f64().to_physical(scale).to_i32_round(),
                 damage,
-                self.geometry(),
             )
         } {
             slog::error!(log, "egui rendering error: {}", err);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -310,6 +310,7 @@ impl EguiFrame {
         r: &mut Gles2Renderer,
         frame: &Gles2Frame,
         location: Point<i32, Physical>,
+        damage: &[Rectangle<i32, Logical>],
     ) -> Result<(), Gles2Error> {
         use rendering::GlState;
 
@@ -327,6 +328,7 @@ impl EguiFrame {
                 frame,
                 gl,
                 location,
+                damage,
                 self.size,
                 self.scale,
                 self.mesh
@@ -392,7 +394,7 @@ impl RenderElement<Gles2Renderer, Gles2Frame, Gles2Error, Gles2Texture> for Egui
         frame: &mut Gles2Frame,
         scale: f64,
         location: Point<i32, Logical>,
-        _damage: &[Rectangle<i32, Logical>],
+        damage: &[Rectangle<i32, Logical>],
         log: &slog::Logger,
     ) -> Result<(), Gles2Error> {
         if let Err(err) = unsafe {
@@ -401,6 +403,7 @@ impl RenderElement<Gles2Renderer, Gles2Frame, Gles2Error, Gles2Texture> for Egui
                 renderer,
                 frame,
                 location.to_f64().to_physical(scale).to_i32_round(),
+                damage,
             )
         } {
             slog::error!(log, "egui rendering error: {}", err);

--- a/src/rendering/mod.rs
+++ b/src/rendering/mod.rs
@@ -208,7 +208,10 @@ impl GlState {
         )
         .to_f64();
 
-        if let Some(damage) = damage.iter().find(|d| d.overlaps(clip_rect.to_i32_round())) {
+        for damage in damage
+            .iter()
+            .filter(|d| d.overlaps(clip_rect.to_i32_round()))
+        {
             let texture = match mesh.texture_id {
                 TextureId::Egui => self.egui_texture,
                 TextureId::User(_) => unimplemented!(),

--- a/src/rendering/mod.rs
+++ b/src/rendering/mod.rs
@@ -232,17 +232,22 @@ impl GlState {
                 ffi::STREAM_DRAW,
             );
 
-            // That is not need now? If we remove that from it it makes the argument size and scale for upper function
-            // also not need, is that right?
             let screen_space = Rectangle::from_loc_and_size((0, 0), size);
 
             let scissor_box: Rectangle<i32, Physical> = clip_rect
+                .intersection(damage.to_f64())
+                .unwrap()
                 .to_physical(scale)
                 .intersection(screen_space.to_f64())
                 .unwrap()
                 .to_i32_round();
 
-            gl.Scissor(damage.loc.x, damage.loc.y, damage.size.w, damage.size.h);
+            gl.Scissor(
+                scissor_box.loc.x,
+                scissor_box.loc.y,
+                scissor_box.size.w,
+                scissor_box.size.h,
+            );
             gl.DrawElements(
                 ffi::TRIANGLES,
                 mesh.indices.len() as i32,

--- a/src/rendering/mod.rs
+++ b/src/rendering/mod.rs
@@ -5,7 +5,6 @@ use egui::{
 };
 use smithay::{
     backend::renderer::gles2::{ffi, Gles2Error, Gles2Frame, Gles2Renderer},
-    nix::sys::socket::sockopt::ReceiveTimeout,
     utils::{Logical, Physical, Point, Rectangle, Size},
 };
 use std::{ffi::CStr, os::raw::c_char, sync::Arc};


### PR DESCRIPTION
This PR adds optional usage of needs_repaint from egui.
This enables using Egui in reactive mode as in the demo https://emilk.github.io/egui/index.html
Damage will be reported on the whole EguiState if:
- an input event happened, for example mouse position was passed to EguiState
- a widget calls request_repaint on CtxRef when building the ui

Some thoughts:
- rename enable_reactive_mode and disable_reactive_mode to reactive_mode/continuous_mode, or make only one function called set_reactive_mode with takes a bool
- draw function currently ignores damage reported to it, I think it needs too take that into account? But I am not sure how this should be implemented.
