### PR TITLE
Update `egui` to 0.29

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,9 @@ license = "MIT"
 
 [dependencies]
 cgmath = "0.18"
-egui = "0.23"
-egui_glow = "0.23"
-egui_extras = { version = "0.23", optional = true }
+egui = "0.29"
+egui_glow = "0.29"
+egui_extras = { version = "0.29", optional = true }
 img = { version = "0.24", default-features = false, optional = true, package = "image" }
 memoffset = "0.9"
 lazy_static = { version = "1.4.0", optional = true }
@@ -18,7 +18,7 @@ xkbcommon = "0.7"
 [dependencies.smithay]
 version = "0.3"
 git = "https://github.com/Smithay/smithay.git"
-rev = "e27fd27ca"
+rev = "3b0ecce"
 default-features = false
 features = ["renderer_glow", "wayland_frontend"]
 
@@ -34,12 +34,12 @@ jpg = ["image", "egui_extras/image", "img/jpeg"]
 
 [dev-dependencies]
 anyhow = "1.0"
-egui_demo_lib = "0.23"
+egui_demo_lib = "0.29"
 tracing-subscriber = "0.3"
 
 [dev-dependencies.smithay]
 version = "0.3"
 git = "https://github.com/Smithay/smithay.git"
-rev = "e27fd27ca"
+rev = "3b0ecce"
 default-features = false
 features = ["backend_winit"]


### PR DESCRIPTION
This currently fails to compile:

```
error[E0308]: mismatched types
   --> src/lib.rs:289:58
    |
289 |                     .with_context(|context| Painter::new(context.clone(), "", None))?
    |                                             ------------ ^^^^^^^^^^^^^^^ expected `Rc<Context>`, found `Arc<Context>`
    |                                             |
    |                                             arguments to this function are incorrect
    |
    = note: expected struct `Rc<egui_glow::painter::Context>`
               found struct `Arc<egui_glow::painter::Context
```

https://github.com/emilk/egui/pull/3598 changed this to use `Rc` instead of `Arc`. Smithay's `GlowRenderer::with_context` passes an `&Arc<Context>`. Not sure what can be done other than Smithay using `Rc`, or using a different glow context for egui...